### PR TITLE
Updated node-sass depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "copy-webpack-plugin": "^3.0.1",
     "css-loader": "^0.23.1",
     "file-loader": "^0.9.0",
-    "node-sass": "^3.8.0",
+    "node-sass": "^4.9.0",
     "open-browser-webpack-plugin": "0.0.2",
     "postcss-loader": "^0.11.0",
     "sass-loader": "^4.0.0",


### PR DESCRIPTION
Ran into an issue where this version of node-sass wouldn't install on Windows 10 64bit. This did the trick.